### PR TITLE
Duplicate parameter name

### DIFF
--- a/types/user/resource.pp
+++ b/types/user/resource.pp
@@ -18,7 +18,6 @@ type Accounts::User::Resource = Struct[
     Optional[gid]                      => Accounts::User::Uid,
     Optional[group]                    => Accounts::User::Name,
     Optional[groups]                   => Array[Accounts::User::Name],
-    Optional[name]                     => Accounts::User::Name,
     Optional[home]                     => Stdlib::Unixpath,
     Optional[home_mode]                => Stdlib::Filemode,
     Optional[ignore_password_if_empty] => Boolean,


### PR DESCRIPTION

## Summary
The following line is present twice:
```
    Optional[name]                     => Accounts::User::Name,
```
One of them should be removed as a duplicate.

## Additional Context
Puppet server throws a:
```
2024-02-28T09:30:24.691+01:00 WARN  [qtp922522377-52] [puppetserver] Puppet The key '["name"]' is declared more than once (file: /etc/puppetlabs/code/environments/production/modules/accounts/types/user/resource.pp, line: 30, column: 40)
```

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)
